### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       AUTOSIGN: '/usr/local/bin/csr-sign'
       AUTOSIGN_CFG: '/etc/puppetlabs/vault/production/csr.yaml'
       DNS_ALT_NAMES: 'puppet,puppet.ghn.me,puppetca,puppetca.ghn.me'
-      JAVA_ARGS: '-Xms1G -Xmx1G -XX:MaxPermSize=256m'
+      JAVA_ARGS: '-Xms1G -Xmx1G'
       TCP_PORTS: '8140'
     entrypoint: sh -c "until [ -s /var/local/deployed_r10k ]; do echo 'Waiting for R10K'; sleep 5; done; /entrypoint.sh puppetserver foreground"
     restart: unless-stopped


### PR DESCRIPTION
`OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0`
