### PR TITLE
Remove docker system prune cron jobs

### DIFF
--- a/data/roles/mini.yaml
+++ b/data/roles/mini.yaml
@@ -5,13 +5,6 @@
 docker::docker_users:
   - vlad
 
-# Cron jobs
-profile::base::cron_jobs:
-  'Docker Clean':
-    command: 'docker system prune --force 2>&1 | /usr/bin/logger -t CleanUp'
-    minute: '2'
-    hour: '2'
-
 # Samba
 samba::server::workgroup: 'WORKGROUP'
 samba::server::server_string: 'Mini'

--- a/data/roles/rhea.yaml
+++ b/data/roles/rhea.yaml
@@ -23,13 +23,6 @@ docker::docker_users:
   - ubuntu
   - vlad
 
-# Cron jobs
-profile::base::cron_jobs:
-  'Docker Clean':
-    command: 'docker system prune --force 2>&1 | /usr/bin/logger -t CleanUp'
-    minute: '2'
-    hour: '2'
-
 # Firewall rules
 profile::linuxfw::rules:
   '11 accept OVH SLA monitoring':

--- a/spec/acceptance/support/profiles/base.rb
+++ b/spec/acceptance/support/profiles/base.rb
@@ -40,7 +40,7 @@ shared_examples 'profile::base' do
   end
 
   describe cron do
-    it { is_expected.to have_entry '* * * * * true' }
+    it { is_expected.to have_entry '2 2 * * * echo "test" 2>&1 | /usr/bin/logger -t CronTest' }
   end
 
   describe file('/tmp/foo.ini') do

--- a/spec/classes/base_spec.rb
+++ b/spec/classes/base_spec.rb
@@ -31,7 +31,10 @@ describe 'profile::base' do
         end
 
         it { is_expected.to contain_ssh_authorized_key('hiera-test-key') }
-        it { is_expected.to contain_cron('test').with_command('true') }
+        it do
+          is_expected.to contain_cron('test')
+            .with_command('echo "test" 2>&1 | /usr/bin/logger -t CronTest')
+        end
         it { is_expected.to contain_ini_setting('test setting') }
         it { is_expected.to contain_package('htop') }
 

--- a/spec/fixtures/data/common.yaml
+++ b/spec/fixtures/data/common.yaml
@@ -19,7 +19,9 @@ profile::base::ssh_authorized_keys:
 # Cron Jobs
 profile::base::cron_jobs:
   'test':
-    command: 'true'
+    command: 'echo "test" 2>&1 | /usr/bin/logger -t CronTest'
+    minute: '2'
+    hour: '2'
 
 # INI Settings
 profile::base::ini_settings:


### PR DESCRIPTION
These will also remove containers that should exists in a stopped state.

R10K container for example, which only wakes up to run deployment.

Removing this until a filter (ex: label) is available