### PR TITLE
Add a custom Docker class

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure('2') do |config|
   # Provision
   config.vm.provision 'shell', inline: <<-SHELL
     # Update APT
+    export DEBIAN_FRONTEND=noninteractive
     apt-get -qy update && apt-get -qy upgrade
 
     # Add gateway to hosts

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -4,7 +4,6 @@ class profile::docker {
   if $::virtual == 'docker' {
     warning('Docker in Docker is not yet supported!')
   } else {
-    # Fix until the docker module supports the latest repository and package
     if $facts['lsbdistid'] == 'Ubuntu' {
       # Docker main class
       class { '::docker':

--- a/dist/profile/manifests/docker_vgh.pp
+++ b/dist/profile/manifests/docker_vgh.pp
@@ -1,0 +1,41 @@
+# Vlad's Docker Profile
+class profile::docker_vgh {
+  # Docker
+  if $::virtual == 'docker' {
+    warning('Docker in Docker is not yet supported!')
+  } else {
+    require ::apt
+
+    case $::osfamily {
+    'Debian': {
+      $os_string = downcase($::operatingsystem)
+
+      apt::source { 'docker':
+        location => "https://download.docker.com/linux/${os_string}",
+        release  => $::lsbdistcodename,
+        repos    => 'stable',
+        key      => {
+          'id'     => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
+          'source' => "https://download.docker.com/linux/${os_string}/gpg",
+        },
+      }
+
+      package { 'docker-ce':
+        ensure  => present,
+        require => [Apt::Source['docker'], Class['apt::update']],
+      }
+
+      package { ['docker.io','docker-engine']:
+        ensure => absent,
+      }
+
+      service { 'docker':
+        ensure  => running,
+        enable  => true,
+        require => Package['docker-ce'],
+      }
+    }
+    default: { warning("Docker is not yet supported on ${::osfamily}!") }
+    }
+  }
+}

--- a/dist/role/manifests/mini.pp
+++ b/dist/role/manifests/mini.pp
@@ -4,6 +4,6 @@ class role::mini {
   include ::profile::log
   include ::profile::git
   include ::profile::puppet::agent
-  include ::profile::docker
+  include ::profile::docker_vgh
   include ::profile::samba
 }

--- a/dist/role/manifests/ogstor.pp
+++ b/dist/role/manifests/ogstor.pp
@@ -4,6 +4,6 @@ class role::ogstor {
   include ::profile::log
   include ::profile::git
   include ::profile::puppet::agent
-  include ::profile::docker
+  include ::profile::docker_vgh
   include ::profile::samba
 }

--- a/dist/role/manifests/rhea.pp
+++ b/dist/role/manifests/rhea.pp
@@ -10,5 +10,5 @@ class role::rhea {
   include ::profile::vgs
   include ::profile::puppet::agent
   include ::profile::puppet::master
-  include ::profile::docker
+  include ::profile::docker_vgh
 }

--- a/spec/acceptance/support/profiles/docker_vgh.rb
+++ b/spec/acceptance/support/profiles/docker_vgh.rb
@@ -2,7 +2,7 @@ shared_examples 'profile::docker' do
   virtual = command('/opt/puppetlabs/bin/facter virtual').stdout.chomp
 
   if virtual != 'docker'
-    describe package('docker') do
+    describe package('docker-ce') do
       it { is_expected.to be_installed }
     end
 
@@ -13,19 +13,6 @@ shared_examples 'profile::docker' do
 
     describe file('/var/run/docker.sock') do
       it { is_expected.to be_socket }
-    end
-
-    describe file('/usr/local/bin/docker-compose') do
-      it { is_expected.to be_executable }
-    end
-
-    describe docker_image('busybox:latest') do
-      it { is_expected.to exist }
-    end
-
-    describe docker_container('test') do
-      it { is_expected.to exist }
-      it { is_expected.to be_running }
     end
   end
 end

--- a/spec/acceptance/support/roles/mini.rb
+++ b/spec/acceptance/support/roles/mini.rb
@@ -3,6 +3,6 @@ shared_examples 'role::mini' do
   it_behaves_like 'profile::log'
   it_behaves_like 'profile::git'
   it_behaves_like 'profile::puppet::agent'
-  it_behaves_like 'profile::docker'
+  it_behaves_like 'profile::docker_vgh'
   it_behaves_like 'profile::samba'
 end

--- a/spec/acceptance/support/roles/ogstor.rb
+++ b/spec/acceptance/support/roles/ogstor.rb
@@ -3,6 +3,6 @@ shared_examples 'role::ogstor' do
   it_behaves_like 'profile::log'
   it_behaves_like 'profile::git'
   it_behaves_like 'profile::puppet::agent'
-  it_behaves_like 'profile::docker'
+  it_behaves_like 'profile::docker_vgh'
   it_behaves_like 'profile::samba'
 end

--- a/spec/acceptance/support/roles/rhea.rb
+++ b/spec/acceptance/support/roles/rhea.rb
@@ -9,5 +9,5 @@ shared_examples 'role::rhea' do
   it_behaves_like 'profile::vgs'
   it_behaves_like 'profile::puppet::agent'
   it_behaves_like 'profile::puppet::master'
-  it_behaves_like 'profile::docker'
+  it_behaves_like 'profile::docker_vgh'
 end

--- a/spec/classes/docker_vgh_spec.rb
+++ b/spec/classes/docker_vgh_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'profile::docker_vgh' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('profile::docker_vgh') }
+
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_class('apt') }
+          it { is_expected.to contain_apt__source('docker') }
+          it { is_expected.to contain_package('docker-ce') }
+          it do
+            is_expected.to contain_package('docker-engine').with(
+              'ensure' => 'absent'
+            )
+          end
+          it do
+            is_expected.to contain_package('docker.io').with(
+              'ensure' => 'absent'
+            )
+          end
+          it do
+            is_expected.to contain_service('docker').with(
+              'ensure' => 'running',
+              'enable' => true
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because the approved module is not maintained anymore and is unusable with newer Puppet and Apt module